### PR TITLE
Project marketing assets

### DIFF
--- a/C01/project-metadata/C01-ProjectId612-metadata.json
+++ b/C01/project-metadata/C01-ProjectId612-metadata.json
@@ -102,11 +102,11 @@
         }
     ]
   },
-  "regen:landStory": "For years, the land between Tsavo East and Tsavo West National parks in Kenya served both as home to a slowly failing cattle ranch and as the main migration corridor for local wildlife moving between the two National Parks. When we first encountered Rukinga, the community and the wildlife were at odds. Rukinga was a bruised, balding land, barren of wildlife. Cattle had grazed the fields into dust, poachers slipped on and off the ranch with ease, and trees were being clear cut along the area’s critical rainwater basin.",
   "regen:landStewardStory": "In 1998, the local community supported our plan to establish the Rukinga Wildlife Sanctuary that covers 80,000 acres of forest. We established a community works project so local residents had an alternative income stream in place of poaching and clear cutting​. We brought on locally hired rangers and trained them to be wilderness guardians. We convinced the owners of the cattle to remove the cattle from the land to reduce conflict over resources.",
   "regen:landStewardStoryTitle": "The project area is home to a fantastic diversity of over 50 species of large mammals including elephants, zebras, lions, cheetahs and leopards.",
   "regen:videoURL": {
     "@type": "schema:URL",
     "@value": "https://player.vimeo.com/video/238682641"
-  }
+  },
+  "regen:creditText": ""
 }

--- a/C01/project-metadata/C01-ProjectId612-metadata.json
+++ b/C01/project-metadata/C01-ProjectId612-metadata.json
@@ -108,5 +108,5 @@
     "@type": "schema:URL",
     "@value": "https://player.vimeo.com/video/238682641"
   },
-  "regen:creditText": ""
+  "regen:creditText": "Photography of Kasigau by Filip Agoo"
 }

--- a/C01/project-metadata/C01-ProjectId612-metadata.json
+++ b/C01/project-metadata/C01-ProjectId612-metadata.json
@@ -20,7 +20,7 @@
   "regen:projectDeveloper": {
     "@type": "regen:OrganizationDisplay",
     "schema:name": "Wildlife Works Carbon LLC",
-    "schema:description": "Wildlife Works is the world's leading REDD+ program development and management company.",
+    "schema:description": "Wildlife Works is the world''s leading REDD+ program development and management company.",
     "regen:showOnProjectPage": true
   },
   "regen:projectType": "Agriculture Forestry and Other Land Use",
@@ -69,6 +69,7 @@
       }
     },
     "type": "Feature",
+    "place_name": "Taita–Taveta, Kenya",
     "geometry": {
       "type": "Point",
       "coordinates": [
@@ -76,5 +77,36 @@
         -3.910022
       ]
     }
+  },
+  "regen:previewPhoto": {
+    "@type": "schema:URL",
+    "@value": "https://regen-registry.s3.amazonaws.com/projects/kasigau/kasigau.png"
+  },
+  "regen:galleryPhotos": {
+    "@list": [
+        {
+            "@type": "schema:URL",
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/kasigau/image1.png"
+        },
+        {
+            "@type": "schema:URL",
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/kasigau/image2.png"
+        },
+        {
+            "@type": "schema:URL",
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/kasigau/image3.png"
+        },
+        {
+            "@type": "schema:URL",
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/kasigau/image4.png"
+        }
+    ]
+  },
+  "regen:landStory": "For years, the land between Tsavo East and Tsavo West National parks in Kenya served both as home to a slowly failing cattle ranch and as the main migration corridor for local wildlife moving between the two National Parks. When we first encountered Rukinga, the community and the wildlife were at odds. Rukinga was a bruised, balding land, barren of wildlife. Cattle had grazed the fields into dust, poachers slipped on and off the ranch with ease, and trees were being clear cut along the area’s critical rainwater basin.",
+  "regen:landStewardStory": "In 1998, the local community supported our plan to establish the Rukinga Wildlife Sanctuary that covers 80,000 acres of forest. We established a community works project so local residents had an alternative income stream in place of poaching and clear cutting​. We brought on locally hired rangers and trained them to be wilderness guardians. We convinced the owners of the cattle to remove the cattle from the land to reduce conflict over resources.",
+  "regen:landStewardStoryTitle": "The project area is home to a fantastic diversity of over 50 species of large mammals including elephants, zebras, lions, cheetahs and leopards.",
+  "regen:videoURL": {
+    "@type": "schema:URL",
+    "@value": "https://player.vimeo.com/video/238682641"
   }
 }

--- a/C01/project-metadata/C01-ProjectId934-metadata.json
+++ b/C01/project-metadata/C01-ProjectId934-metadata.json
@@ -69,6 +69,7 @@
       }
     },
     "type": "Feature",
+    "place_name": "Mai Ndombe, Democratic Republic of the Congo, Africa",
     "geometry": {
       "type": "Point",
       "coordinates": [
@@ -76,5 +77,35 @@
         -1.958494
       ]
     }
-  }
+  },
+  "regen:previewPhoto": {
+    "@type": "schema:URL",
+    "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/preview-photo.jpg"
+  },
+  "regen:galleryPhotos": {
+    "@list": [
+        {
+            "@type": "schema:URL",
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image1.jpg"
+        },
+        {
+            "@type": "schema:URL",
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image2.jpg"
+        },
+        {
+            "@type": "schema:URL",
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image3.jpg"
+        },
+        {
+            "@type": "schema:URL",
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image4.jpg"
+        }
+    ]
+  },
+  "regen:videoURL": {
+    "@type": "schema:URL",
+    "@value": "https://www.youtube.com/embed/_4wHY99fm-w"
+  },
+  "schema:creditText": "Filip C Agoo, Everland Marketing"
 }
+

--- a/C01/project-metadata/C01-ProjectId934-metadata.json
+++ b/C01/project-metadata/C01-ProjectId934-metadata.json
@@ -86,7 +86,7 @@
     "@list": [
         {
             "@type": "schema:URL",
-            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image-1.jpg"
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image-1.png"
         },
         {
             "@type": "schema:URL",
@@ -98,7 +98,7 @@
         },
         {
             "@type": "schema:URL",
-            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image-4.jpg"
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image-4.png"
         }
     ]
   },

--- a/C01/project-metadata/C01-ProjectId934-metadata.json
+++ b/C01/project-metadata/C01-ProjectId934-metadata.json
@@ -86,19 +86,19 @@
     "@list": [
         {
             "@type": "schema:URL",
-            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image1.jpg"
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image-1.jpg"
         },
         {
             "@type": "schema:URL",
-            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image2.jpg"
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image-2.jpg"
         },
         {
             "@type": "schema:URL",
-            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image3.jpg"
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image-3.jpg"
         },
         {
             "@type": "schema:URL",
-            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image4.jpg"
+            "@value": "https://regen-registry.s3.amazonaws.com/projects/mai-ndombe/image-4.jpg"
         }
     ]
   },
@@ -106,6 +106,6 @@
     "@type": "schema:URL",
     "@value": "https://www.youtube.com/embed/_4wHY99fm-w"
   },
-  "schema:creditText": "Filip C Agoo, Everland Marketing"
+  "schema:creditText": "Photography of Mai Ndombe by Filip Agoo"
 }
 


### PR DESCRIPTION
Related: regen-network/regen-registry#702

This restores images marketing text, and other assets that are held in metadata.

- add landStewardStory, galleryPhotos, previewPhoto, videoURL, and place_name to kasigau (from previous metadata)
- add galleryPhotos, previewPhoto, videoURL, and place_name to mai-ndombe