### PR TITLE
Update C01-verified-carbon-standard-credit-class.json

### DIFF
--- a/C01/credit-class-metadata/C01-verified-carbon-standard-credit-class.json
+++ b/C01/credit-class-metadata/C01-verified-carbon-standard-credit-class.json
@@ -18,7 +18,7 @@
     }
   },
   "@type": "regen:CreditClass",
-  "schema:name": "Verified Carbon Standard Credit Class",
+  "schema:name": "Verified Carbon Standard",
   "schema:description": "This credit class provides a vehicle for nature based Verified Carbon Units (VCUs) to enter the blockchain space via issuance on Regen Ledger. It can be used by project developers, credit brokers, and other stakeholders interested in digitizing carbon credits issued by the VCS program to make them available in the emerging world of decentralized finance.",
   "schema:url":
   {


### PR DESCRIPTION
As discussed, removes "Credit Class" at the end of the credit class `schema:name`.

The `metadata` for C01 credit class has been updated to the new IRI on mainnet: https://regen.aneka.io/txs/7283EF9A0BE09A33CC244DB3B0EB05DC01A8B33E60B69C731DE2F0F57F837E2C