### PR TITLE
Update @type for project metadata to C01-Project

### DIFF
--- a/C01/project-metadata/C01-ProjectId612-metadata.json
+++ b/C01/project-metadata/C01-ProjectId612-metadata.json
@@ -6,7 +6,7 @@
     "unit": "http://qudt.org/vocab/unit/",
     "xsd": "http://www.w3.org/2001/XMLSchema#"
   },
-  "@type": "regen:Project",
+  "@type": "regen:C01-Project",
   "schema:name": "The Kasigau Corridor REDD Project - Phase II The Community Ranches",
   "regen:vcsProjectId": {
     "@type": "xsd:unsignedInt",

--- a/C01/project-metadata/C01-ProjectId934-metadata.json
+++ b/C01/project-metadata/C01-ProjectId934-metadata.json
@@ -6,7 +6,7 @@
     "unit": "http://qudt.org/vocab/unit/",
     "xsd": "http://www.w3.org/2001/XMLSchema#"
   },
-  "@type": "regen:Project",
+  "@type": "regen:C01-Project",
   "schema:name": "The Mai Ndombe REDD+ Project",
   "regen:vcsProjectId": {
     "@type": "xsd:unsignedInt",


### PR DESCRIPTION
Part of: https://github.com/regen-network/regen-registry/issues/941

This adjusts the `@type` for the project metadata to be credit class specific.